### PR TITLE
Default parameter for --build location when using as a python library 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ found_plans/
 /experiments/structural-symmetries-pruning/data/
 /misc/.tox/
 /misc/autodoc/downward-xmlrpc.secret
+Pipfile
+Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea/
+.vscode/
 .tox/
 build/
 builds/

--- a/driver/util.py
+++ b/driver/util.py
@@ -5,7 +5,7 @@ from . import returncodes
 
 DRIVER_DIR = os.path.abspath(os.path.dirname(__file__))
 REPO_ROOT_DIR = os.path.dirname(DRIVER_DIR)
-BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "builds") 
+BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "builds")
 
 
 def get_elapsed_time():

--- a/driver/util.py
+++ b/driver/util.py
@@ -5,7 +5,12 @@ from . import returncodes
 
 DRIVER_DIR = os.path.abspath(os.path.dirname(__file__))
 REPO_ROOT_DIR = os.path.dirname(DRIVER_DIR)
-BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "builds")
+
+#Check the builds path as installed by build.py
+BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "builds") 
+if not os.path.exists(BUILDS_DIR):
+    #Check the builds path as installed by _custom_build.py
+    BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "forbiditeritive", "builds") 
 
 
 def get_elapsed_time():

--- a/driver/util.py
+++ b/driver/util.py
@@ -5,12 +5,7 @@ from . import returncodes
 
 DRIVER_DIR = os.path.abspath(os.path.dirname(__file__))
 REPO_ROOT_DIR = os.path.dirname(DRIVER_DIR)
-
-#Check the builds path as installed by build.py
 BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "builds") 
-if not os.path.exists(BUILDS_DIR):
-    #Check the builds path as installed by _custom_build.py
-    BUILDS_DIR = os.path.join(REPO_ROOT_DIR, "forbiditeritive", "builds") 
 
 
 def get_elapsed_time():

--- a/forbiditerative/fast-downward.py
+++ b/forbiditerative/fast-downward.py
@@ -2,4 +2,6 @@
 
 if __name__ == "__main__":
     from driver.main import main
+    from plan import set_default_build_path
+    set_default_build_path()
     main()

--- a/forbiditerative/fast-downward.py
+++ b/forbiditerative/fast-downward.py
@@ -2,6 +2,6 @@
 
 if __name__ == "__main__":
     from driver.main import main
-    from plan import set_default_build_path
+    from forbiditerative.plan import set_default_build_path
     set_default_build_path()
     main()

--- a/forbiditerative/plan.py
+++ b/forbiditerative/plan.py
@@ -274,28 +274,30 @@ def validate_input(args):
 def set_default_build_path():
     """ 
     Operates directly on sys.argv and sets the default value of --build. Prioritizes builds in this order:
-    1) Any provided --build path, does not modify sys.argv
-    2) If <repo>/builds/BUILD/bin exists, no changes are made to argv and --build will be set to this in the driver.
-    3) If <site-packages>/forbiditeritive/builds/BUILD/bin exists due to the package having been installed as a library,
-       build will be set to this
-    
+    1) Any provided --build path
+    2) <repo>/builds/BUILD/bin if it exists
+    3) <site-packages>/forbiditeritive/builds/BUILD/bin if it exists (the package has been installed as a library)
+
     NOTE: Operating directly on sys.argv is generally considered bad practice but we need to modify the build arg
     before it reaches the upstream driver code, and are unable to pass in a copy to driver. 
     """
     if "--build" in sys.argv:
-        return
+        #A build path has been explicitly provided by the end user, don't modify anything
+        return 
     
     forbiditerative_path = Path(__file__).parent 
     regular_build_path = forbiditerative_path.parent / 'builds' / 'release' / 'bin'    
     if os.path.exists(regular_build_path):
-        return
+        #The driver will look here by default, don't modify argv 
+        return  
     
     package_build_path = forbiditerative_path / 'builds' / 'release' / 'bin'    
     if os.path.exists(package_build_path):
         sys.argv.append("--build")
-        sys.argv.append(package_build_path)
+        sys.argv.append(str(package_build_path))
 
 if __name__ == "__main__":
+    set_default_build_path()
     parser = argparse.ArgumentParser(
         add_help=False)
     lim = parser.add_argument_group(
@@ -331,8 +333,6 @@ if __name__ == "__main__":
     parser.add_argument("--upper-bound-on-number-of-plans", help="The overall bound on the number of plans", type=int, default=1000000)
 
     parser.add_argument("--suppress-planners-output", help="Suppress the output of the individual planners", action="store_true")
-
-    set_default_build_path()
 
     args = parser.parse_args()
 

--- a/forbiditerative/plan.py
+++ b/forbiditerative/plan.py
@@ -298,9 +298,11 @@ def set_default_build_path():
         return
     
     logging.error(f"""
-    No binary directory was found at the default search locations {str(package_build_path)} or {str(regular_build_path)}:
+    No binary directory was found at the default search locations: {str(package_build_path)},
+    {str(regular_build_path)}, or provided via the --build flag.
     If you are building locally from source, run build.py in the main folder.
-    If you are installing as a python package from local source, run "pip install ." in the main folder or if installing from the remote source "pip install git+https://github.com/IBM/forbiditerative.git" 
+    If you are installing as a python package from local source, run "pip install ." in the main folder
+    or if installing from the remote source "pip install git+https://github.com/IBM/forbiditerative.git" 
     If you have manually installed the binaries in a separate location please specify a path to them with the --build argument.
     Note: when installing locally with "pip install -e .", a --build flag must be provided to the binaries.  
     """)

--- a/forbiditerative/plan.py
+++ b/forbiditerative/plan.py
@@ -295,6 +295,16 @@ def set_default_build_path():
     if os.path.exists(package_build_path):
         sys.argv.append("--build")
         sys.argv.append(str(package_build_path))
+        return
+    
+    logging.error(f"""
+    No binary directory was found at the default search locations {str(package_build_path)} or {str(regular_build_path)}:
+    If you are building locally from source, run build.py in the main folder.
+    If you are installing as a python package from local source, run "pip install ." in the main folder or if installing from the remote source "pip install git+https://github.com/IBM/forbiditerative.git" 
+    If you have manually installed the binaries in a separate location please specify a path to them with the --build argument.
+    Note: when installing locally with "pip install -e .", a --build flag must be provided to the binaries.  
+    """)
+    exit(1)
 
 if __name__ == "__main__":
     set_default_build_path()


### PR DESCRIPTION
## Fixes:
Issue #9 

## Description:
I've added a method that modifies argv to add a default path for --build if none is provided. The method will prioritize looking for binaries built in `<repo>/builds/release/bin` followed by looking in `<site-packages>/forbiditerative/builds/release/bin` where it is placed when installing as a library. This prevents the need for library end users who install via pip to specify the `--build` parameter seen below each use:
```
--build $(python -c 'import site; print(site.getsitepackages()[0])')/forbiditerative/builds/release/bin
``` 

The method is called by the two python entry points `plan.py` and `fast-downward.py`. 

## Tests:
I've locally tested building and running with the tox tests and running some examples using the .sh files. I've also tested installing as a package and running examples from the package install.  

## Notes:
`pip install -e .` for me places the binaries in `<site-packages>/builds/release/bin` which I am assuming is unintended behavior, as we probably should not be placing a non-package in the python packages dir. Thus I have not accounted for this location in my PR, and when installing via `pip install -e .` people will still need to specify this path via `--build`, which to my knowledge is the original behavior. 

Please let me know if you have any feedback and I will do my best to resolve and respond. 