### PR TITLE
pass default --build flag for local install

### DIFF
--- a/forbiditerative/plan.py
+++ b/forbiditerative/plan.py
@@ -293,8 +293,9 @@ def set_default_build_path():
     regular_build_path = forbiditerative_path.parent / 'builds' / 'release' / 'bin'    
     if os.path.exists(regular_build_path):
         logging.info(f"Local build found under {str(regular_build_path)}")
-        #The driver will look here by default, don't modify argv 
-        return  
+        sys.argv.append("--build")
+        sys.argv.append(str(regular_build_path))
+        return
     
     package_build_path = forbiditerative_path / 'builds' / 'release' / 'bin'    
     if os.path.exists(package_build_path):


### PR DESCRIPTION
## Overview:

This fixes an  bug where an installation of the pip package conflicts with a local repo preventing running module in the local repo.

## Details: 
In the event that both a pip package version has been installed (which we will say has been installed at `<site-packages>`) and a local copy exists (at a path `<repo>`), running either `fast-downward.py` or `plan.py` as a module: `pip -m forbiditerative.plan` in `<repo>` will call the local copy  `<repo>/forbiditerative/plan.py` to be invoked, rather than the  `<site-packages>/forbiditerative/plan.py` due to [the behavior of the `python -m` to search the working directory first](https://docs.python.org/3/using/cmdline.html#cmdoption-m). 

`<repo>/forbiditerative/plan.py` will search for `builds` finding them in the local repo then attempting to call the driver.  Normally this would proceed to fail  due to not being able to find the driver, unless PYTHONPATH is set to the `<repo>` (as done in the shell script entry points). However since a pip package containing the driver at `<site-packages>` exists, this module is invoked from the local copy. Since `<repo>/forbiditerative/plan.py` found its local binaries at `<repo>/builds`, it hands control to the driver, assuming its the `<repo>/driver` module which will be able to locate `<repo>/builds`. But in this case it's not the `<repo>/driver` module but the `<site-packages>/driver` module which will look for builds at `<site-packages>/builds`, an invalid build location. 

To fix this we simply pass the `<repo>/builds` as a default `--build` argument if it exists so that whatever driver module is being used, it will always use the builds at the path found by `plan.py`.